### PR TITLE
Set .podspec homepage to "n/a"

### DIFF
--- a/ios/RNTusClient.podspec
+++ b/ios/RNTusClient.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNTusClient
                    DESC
-  s.homepage     = ""
+  s.homepage     = "n/a"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
This is necessary in order to avoid this error:

Fetching podspec for `RNTusClient` from `../node_modules/react-native-tus-client/ios`
[!] The `RNTusClient` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.